### PR TITLE
Correction to speaker info for Open AI Workshop website #37

### DIFF
--- a/data/en/2020/open-source-ai-workshop/speakers.yml
+++ b/data/en/2020/open-source-ai-workshop/speakers.yml
@@ -15,5 +15,5 @@ items:
     title: "Research Associate, Large Scale Data and Systems Group (Imperial College London)"
     img: luo_mai.jpg
   - name: "Barry O’Sullivan"
-    title: "President (AI4EU - European AI Association); Professor (University College Cork, Ireland)"
+    title: "President (EurAI - European AI Association), Professor (University College Cork, Ireland)"
     img: barry-o_sullivan.jpg


### PR DESCRIPTION
Fix #37

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>