### PR TITLE
initial thoughts on past events listing

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -3,12 +3,12 @@ import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import EventsDataFetcher from './components/EventsDataFetcher';
+import Wrapper from './components/Wrapper';
 
 const App = () => (
   <div className="container">
-    <h1>Upcoming Events</h1>
-    <EventsDataFetcher />
+    <h1>Events</h1>
+    <Wrapper />
   </div>
 );
 

--- a/js/components/EventHelpers.js
+++ b/js/components/EventHelpers.js
@@ -100,6 +100,17 @@ export const EVENT_TYPES = [
   },
 ]
 
+export const EVENT_TIME = [
+  {
+    id: "upcoming_only",
+    name: "Upcoming events"
+  },
+  {
+    id: "past_event_only",
+    name: "Past events"
+  },
+]
+
 export function checkEventWorkingGroups(events, filter) {
   for (let i=0; i<events.length; i++) {
     if (events[i].publish_to.includes(filter.id)) { // as long as find one event has the working group
@@ -222,4 +233,11 @@ export function alphaOrder(array) {
     return array.sort((a, b) => a?.name.localeCompare(b?.name))
   }
 
+}
+
+export function hasSelectedItems(items) {
+  let selectedItems = getSelectedItems(items)
+  if (selectedItems && selectedItems.length > 0) {
+    return selectedItems
+  } else return false
 }

--- a/js/components/Wrapper.js
+++ b/js/components/Wrapper.js
@@ -18,7 +18,6 @@ const Wrapper = () => {
     <div>
       <button className="btn btn-default margin-right-20" onClick={showUpcoming}> Upcoming events </button>
       <button className="btn btn-default" onClick={showPastEvents}> Past events </button>
-
       { upcoming == true ? <EventsDataFetcher /> : <PastEventsDataFetcher /> }
     </div>
   )

--- a/js/components/Wrapper.js
+++ b/js/components/Wrapper.js
@@ -17,7 +17,7 @@ const Wrapper = () => {
   return (
     <div>
       <button className="btn btn-default margin-right-20" onClick={showUpcoming}> Upcoming events </button>
-      <button className="btn btn-default" onClick={showPastEvents}> Past events </button>
+      <button className="btn btn-default" onClick={showPastEvents}> Past events together with upcoming events </button>
       { upcoming == true ? <EventsDataFetcher /> : <PastEventsDataFetcher /> }
     </div>
   )

--- a/js/components/Wrapper.js
+++ b/js/components/Wrapper.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import EventsDataFetcher from './EventsDataFetcher';
+import PastEventsDataFetcher from './pastEvents/PastEventsDataFetcher';
+
+const Wrapper = () => {
+
+  const [upcoming, setUpcoming] = useState(true)
+
+  const showPastEvents = () => {
+    setUpcoming(false)
+  }
+
+  const showUpcoming = () => {
+    setUpcoming(true)
+  }
+
+  return (
+    <div>
+      <button className="btn btn-default margin-right-20" onClick={showUpcoming}> Upcoming events </button>
+      <button className="btn btn-default" onClick={showPastEvents}> Past events </button>
+
+      { upcoming == true ? <EventsDataFetcher /> : <PastEventsDataFetcher /> }
+    </div>
+  )
+}
+
+export default Wrapper

--- a/js/components/pastEvents/FilteredPastEventsList.js
+++ b/js/components/pastEvents/FilteredPastEventsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import EventCard from '../EventCard';
 import Loading from '../Loading';
 
-const FilteredPastEventsList = ({ events, isFetchingMore, fetchMore, groupParas, typeParas }) => {
+const FilteredPastEventsList = ({ events, isFetchingMore, fetchMore }) => {
 
   return (
     <> 
@@ -12,11 +12,11 @@ const FilteredPastEventsList = ({ events, isFetchingMore, fetchMore, groupParas,
             <EventCard event={event} />
           </div>
         ))}
-  
-        <div className="past-event-container">
-          { isFetchingMore && <Loading /> }
-          { !isFetchingMore && <button className="btn btn-primary" onClick={() => fetchMore(groupParas, typeParas)}>New Load More</button>}
-        </div>
+      </div>
+
+      <div className="text-center">
+        { isFetchingMore && <Loading /> }
+        { !isFetchingMore && <button className="btn btn-primary margin-top-10" onClick={fetchMore}>Load More</button>}
       </div>
 
     </>

--- a/js/components/pastEvents/FilteredPastEventsList.js
+++ b/js/components/pastEvents/FilteredPastEventsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import EventCard from '../EventCard';
 import Loading from '../Loading';
 
-const PastEventsList = ({ events, isFetchingMore, fetchMore, newLoadMore }) => {
+const FilteredPastEventsList = ({ events, isFetchingMore, fetchMore, groupParas, typeParas }) => {
 
   return (
     <> 
@@ -15,7 +15,7 @@ const PastEventsList = ({ events, isFetchingMore, fetchMore, newLoadMore }) => {
   
         <div className="past-event-container">
           { isFetchingMore && <Loading /> }
-          { !isFetchingMore && (!newLoadMore) && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
+          { !isFetchingMore && <button className="btn btn-primary" onClick={() => fetchMore(groupParas, typeParas)}>New Load More</button>}
         </div>
       </div>
 
@@ -23,4 +23,4 @@ const PastEventsList = ({ events, isFetchingMore, fetchMore, newLoadMore }) => {
   )
 }
 
-export default PastEventsList
+export default FilteredPastEventsList

--- a/js/components/pastEvents/PastEventsDataFetcher.js
+++ b/js/components/pastEvents/PastEventsDataFetcher.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import Loading from '../Loading';
+import { alertTypes } from '../AlertsEnum';
+import Alerts from '../Alerts';
+import PastEventsList from './PastEventsList';
+
+const PastEventsDataFetcher = () => {
+
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [events, setEvents] = useState([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [isFetchingMore, setIsFetchingMore] = useState(false)
+
+  const fetchingData = (page) => {
+    fetch(`https://newsroom.eclipse.org/api/events?page=${page}&pagesize=4`)
+      .then((res) => res.json())
+      .then(
+        (result) => {
+          setLoading(false)
+          setIsFetchingMore(false)
+          setEvents([...events, ...result.events])
+        },
+        // Note: it's important to handle errors here
+        // instead of a catch() block so that we don't swallow
+        // exceptions from actual bugs in components.
+        (error) => {
+          setLoading(false)
+          setIsFetchingMore(false)
+          setError(error)
+        }
+      )
+  }
+  
+  // only load once first time
+  useEffect(() => {
+    fetchingData(currentPage)
+  }, [])
+
+  // get more when click on the button
+  const fetchMore = () => {
+    setIsFetchingMore(true)
+    fetchingData(currentPage + 1)
+    setCurrentPage(prev => prev + 1)
+  }
+
+  if (loading) return <Loading />
+  if (error) return <Alerts alertType={alertTypes.ERROR} message={error.message} />
+
+
+  return (
+    <>
+      <p>Past events showing</p>
+      <PastEventsList events={events} />
+
+        <div className="container">
+          <div className="row margin-bottom-20">
+            <div className="col-md-6"></div>
+            <div className="col-md-18 past-event-container">
+              { isFetchingMore && <Loading /> }
+              { !isFetchingMore && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
+            </div>
+          </div>
+        </div>
+    </>
+  )
+}
+
+export default PastEventsDataFetcher

--- a/js/components/pastEvents/PastEventsDataFetcher.js
+++ b/js/components/pastEvents/PastEventsDataFetcher.js
@@ -53,15 +53,15 @@ const PastEventsDataFetcher = () => {
       <p>Past events showing</p>
       <PastEventsList events={events} />
 
-        <div className="container">
-          <div className="row margin-bottom-20">
-            <div className="col-md-6"></div>
-            <div className="col-md-18 past-event-container">
-              { isFetchingMore && <Loading /> }
-              { !isFetchingMore && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
-            </div>
+      <div className="container">
+        <div className="row margin-bottom-20">
+          <div className="col-md-6"></div>
+          <div className="col-md-18 past-event-container">
+            { isFetchingMore && <Loading /> }
+            { !isFetchingMore && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
           </div>
         </div>
+      </div>
     </>
   )
 }

--- a/js/components/pastEvents/PastEventsDataFetcher.js
+++ b/js/components/pastEvents/PastEventsDataFetcher.js
@@ -3,6 +3,8 @@ import Loading from '../Loading';
 import { alertTypes } from '../AlertsEnum';
 import Alerts from '../Alerts';
 import PastEventsList from './PastEventsList';
+import PastEventsFilters from './PastEventsFilters';
+import { getSelectedItems } from '../EventHelpers';
 
 const PastEventsDataFetcher = () => {
 
@@ -12,30 +14,62 @@ const PastEventsDataFetcher = () => {
   const [currentPage, setCurrentPage] = useState(1)
   const [isFetchingMore, setIsFetchingMore] = useState(false)
 
+  const [checkedWorkingGroups, setCheckedWorkingGroups] = useState({})
+  const [checkedTypes, setCheckedTypes] = useState({})
+
+  const [dataWithFilters, setDataWithFilters] = useState([])
+
   const fetchingData = (page) => {
-    fetch(`https://newsroom.eclipse.org/api/events?page=${page}&pagesize=4`)
-      .then((res) => res.json())
-      .then(
-        (result) => {
-          setLoading(false)
-          setIsFetchingMore(false)
-          setEvents([...events, ...result.events])
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
-        (error) => {
-          setLoading(false)
-          setIsFetchingMore(false)
-          setError(error)
-        }
-      )
+    let url = `https://newsroom.eclipse.org/api/events?page=${page}&pagesize=6`
+    fetch(url)
+    .then((res) => res.json())
+    .then(
+      (result) => {
+        setLoading(false)
+        setIsFetchingMore(false)
+        setEvents([...events, ...result.events])
+      },
+      // Note: it's important to handle errors here
+      // instead of a catch() block so that we don't swallow
+      // exceptions from actual bugs in components.
+      (error) => {
+        setLoading(false)
+        setIsFetchingMore(false)
+        setError(error)
+      }
+    )
+  }
+
+  const fetchingDataWithParas = (page, para) => {
+    let url = `https://newsroom.eclipse.org/api/events?page=${page}&pagesize=6&parameters[publish_to]=${para}`
+    fetch(url)
+    .then((res) => res.json())
+    .then(
+      (result) => {
+        setLoading(false)
+        setIsFetchingMore(false)
+        setDataWithFilters([...dataWithFilters, ...result.events])
+      },
+      // Note: it's important to handle errors here
+      // instead of a catch() block so that we don't swallow
+      // exceptions from actual bugs in components.
+      (error) => {
+        setLoading(false)
+        setIsFetchingMore(false)
+        setError(error)
+      }
+    )
   }
   
   // only load once first time
   useEffect(() => {
-    fetchingData(currentPage)
-  }, [])
+    let selectedWorkingGroups = getSelectedItems(checkedWorkingGroups)
+    if (selectedWorkingGroups && selectedWorkingGroups.length > 0) {
+      fetchingDataWithParas(currentPage, selectedWorkingGroups[0])
+    } else {
+      fetchingData(currentPage)
+    }
+  }, [checkedWorkingGroups])
 
   // get more when click on the button
   const fetchMore = () => {
@@ -44,22 +78,33 @@ const PastEventsDataFetcher = () => {
     setCurrentPage(prev => prev + 1)
   }
 
-  if (loading) return <Loading />
-  if (error) return <Alerts alertType={alertTypes.ERROR} message={error.message} />
+  const fetchMoreWithParas = (para) => {
+    setIsFetchingMore(true)
+    fetchingDataWithParas((currentPage + 1), para)
+    setCurrentPage(prev => prev + 1)
+  }
 
+  if (error) return <Alerts alertType={alertTypes.ERROR} message={error.message} />
 
   return (
     <>
       <p>Past events showing</p>
-      <PastEventsList events={events} />
-
       <div className="container">
         <div className="row margin-bottom-20">
-          <div className="col-md-6"></div>
-          <div className="col-md-18 past-event-container">
-            { isFetchingMore && <Loading /> }
-            { !isFetchingMore && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
+          <div className="col-md-6">
+            <PastEventsFilters
+              checkedTypes={checkedTypes}
+              setCheckedTypes={setCheckedTypes}
+            />
+            <PastEventsFilters
+              checkedWorkingGroups={checkedWorkingGroups}
+              setCheckedWorkingGroups={setCheckedWorkingGroups}
+            />
           </div>
+          { loading ? <Loading /> : 
+            (getSelectedItems(checkedWorkingGroups) && getSelectedItems(checkedWorkingGroups).length > 0) ? 
+            <PastEventsList events={dataWithFilters} isFetchingMore={isFetchingMore} fetchMore={fetchMoreWithParas} paras={getSelectedItems(checkedWorkingGroups)[0]} /> :
+            <PastEventsList events={events} isFetchingMore={isFetchingMore} fetchMore={fetchMore} />}
         </div>
       </div>
     </>

--- a/js/components/pastEvents/PastEventsFilters.js
+++ b/js/components/pastEvents/PastEventsFilters.js
@@ -1,9 +1,16 @@
 import React, { useState } from 'react';
 import Checkbox from '../Checkbox';
-import { EVENT_TYPES, WORKING_GROUPS, alphaOrder } from '../EventHelpers';
+import { EVENT_TYPES, WORKING_GROUPS, EVENT_TIME, alphaOrder } from '../EventHelpers';
 import PropTypes from 'prop-types';
 
-const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups, setCheckedWorkingGroups }) => {
+const PastEventsFilters = ({ 
+  checkedTypes, 
+  setCheckedTypes, 
+  checkedWorkingGroups, 
+  setCheckedWorkingGroups, 
+  checkedEventTime, 
+  setCheckedEventTime
+}) => {
   
   const determineInitialState = () => {
     return window.innerWidth > 991
@@ -11,6 +18,7 @@ const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups
 
   const [showTypes, setShowTypes] = useState(determineInitialState())
   const [showWorkingGroups, setShowWorkingGroups] = useState(determineInitialState())
+  const [showEventTime, setShowEventTime] = useState(determineInitialState())
 
   const handleChange = (e) => {
     if (checkedWorkingGroups && setCheckedWorkingGroups) {
@@ -41,6 +49,20 @@ const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups
       }
     }
 
+    if (checkedEventTime && setCheckedEventTime) {
+      if (e.target.checked) {
+        setCheckedEventTime({
+         ...checkedEventTime,
+         [e.target.name]: e.target.checked
+       });
+      } else {
+        setCheckedEventTime({
+           ...checkedEventTime,
+          [e.target.name]: undefined
+        })
+      }
+    }
+
   }
 
   const toggleTypes = () => {
@@ -51,25 +73,29 @@ const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups
     setShowWorkingGroups(!showWorkingGroups)
   }
 
-  const WorkingGroups = () => {
-    if (checkedWorkingGroups && setCheckedWorkingGroups) {
+  const toggleEventTimes = () => {
+    setShowEventTime(!showEventTime)
+  }
+
+  function renderFilterComponent(checkedFilter, filterCheckFunc, filterShowingState, filterShowingFunc, filterDataArray, filterTypeName) {
+    if (checkedFilter && filterCheckFunc) {
       return (
         <> 
           <button
-            onClick={toggleWorkingGroups}
+            onClick={filterShowingFunc}
             className="event-filter-title"
             >
-              CATEGORIES
+              { filterTypeName }
               <i className="fa fa-angle-down event-filter-expandable-icon" aria-hidden="true"></i>
           </button>
-          { showWorkingGroups && 
+          { filterShowingState && 
             <ul className="event-filter-checkbox-list">
-                { alphaOrder(WORKING_GROUPS).map(item => (
+                { filterDataArray.map(item => (
                   <li key={item.id}>
                     <label key={item.id}>
                       <Checkbox
                         name={item.id} 
-                        checked={checkedWorkingGroups[item.id]} 
+                        checked={checkedFilter[item.id]} 
                         onChange={handleChange}
                       />
                       {item.name}
@@ -83,45 +109,14 @@ const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups
     }
   }
 
-
-  const EventTypes = () => {
-    if (checkedTypes && setCheckedTypes) {
-      return (
-        <>
-          <button
-            onClick={toggleTypes}
-            className="event-filter-title"
-          >
-            EVENT TYPE
-            <i className="fa fa-angle-down event-filter-expandable-icon" aria-hidden="true"></i>
-          </button>
-          { showTypes &&
-            <ul className="event-filter-checkbox-list">
-                { alphaOrder(EVENT_TYPES).map(item => (
-                  <li key={item.id}>
-                    <label key={item.id}>
-                      <Checkbox
-                        name={item.id}
-                        checked={checkedTypes[item.id]}
-                        onChange={handleChange}
-                      />
-                      {item.name}
-                    </label>
-                  </li>
-                )) }
-            </ul>
-          }
-        </>
-      )
-    }
-  }
-
   return (
     <div className="margin-bottom-10">
-      {WorkingGroups()}
-      {EventTypes()}
+      {renderFilterComponent(checkedTypes, setCheckedTypes, showTypes, toggleTypes, alphaOrder(EVENT_TYPES), "EVENT TYPE")}
+      {renderFilterComponent(checkedWorkingGroups, setCheckedWorkingGroups, showWorkingGroups, toggleWorkingGroups, alphaOrder(WORKING_GROUPS), "CATEGORIES")}
+      {renderFilterComponent(checkedEventTime, setCheckedEventTime, showEventTime, toggleEventTimes, EVENT_TIME, "TIME")}
     </div>
   )
+
 }
 
 PastEventsFilters.propTypes = {
@@ -129,6 +124,8 @@ PastEventsFilters.propTypes = {
   setCheckedTypes: PropTypes.func,
   checkedWorkingGroups: PropTypes.object,
   setCheckedWorkingGroups: PropTypes.func,
+  checkedEventTime: PropTypes.object,
+  setCheckedEventTime: PropTypes.func,
 }
 
 export default PastEventsFilters

--- a/js/components/pastEvents/PastEventsFilters.js
+++ b/js/components/pastEvents/PastEventsFilters.js
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import Checkbox from '../Checkbox';
+import { EVENT_TYPES, WORKING_GROUPS, alphaOrder } from '../EventHelpers';
+import PropTypes from 'prop-types';
+
+const PastEventsFilters = ({ checkedTypes, setCheckedTypes, checkedWorkingGroups, setCheckedWorkingGroups }) => {
+  
+  const determineInitialState = () => {
+    return window.innerWidth > 991
+  }
+
+  const [showTypes, setShowTypes] = useState(determineInitialState())
+  const [showWorkingGroups, setShowWorkingGroups] = useState(determineInitialState())
+
+  const handleChange = (e) => {
+    if (checkedWorkingGroups && setCheckedWorkingGroups) {
+      if (e.target.checked) {
+        setCheckedWorkingGroups({
+         ...checkedWorkingGroups,
+         [e.target.name]: e.target.checked
+       });
+      } else {
+        setCheckedWorkingGroups({
+           ...checkedWorkingGroups,
+          [e.target.name]: undefined
+        })
+      }
+    }
+
+    if (checkedTypes && setCheckedTypes) {
+      if (e.target.checked) {
+        setCheckedTypes({
+         ...checkedTypes,
+         [e.target.name]: e.target.checked
+       });
+      } else {
+        setCheckedTypes({
+           ...checkedTypes,
+          [e.target.name]: undefined
+        })
+      }
+    }
+
+  }
+
+  const toggleTypes = () => {
+    setShowTypes(!showTypes)
+  }
+
+  const toggleWorkingGroups = () => {
+    setShowWorkingGroups(!showWorkingGroups)
+  }
+
+  const WorkingGroups = () => {
+    if (checkedWorkingGroups && setCheckedWorkingGroups) {
+      return (
+        <> 
+          <button
+            onClick={toggleWorkingGroups}
+            className="event-filter-title"
+            >
+              CATEGORIES
+              <i className="fa fa-angle-down event-filter-expandable-icon" aria-hidden="true"></i>
+          </button>
+          { showWorkingGroups && 
+            <ul className="event-filter-checkbox-list">
+                { alphaOrder(WORKING_GROUPS).map(item => (
+                  <li key={item.id}>
+                    <label key={item.id}>
+                      <Checkbox
+                        name={item.id} 
+                        checked={checkedWorkingGroups[item.id]} 
+                        onChange={handleChange}
+                      />
+                      {item.name}
+                    </label>
+                  </li>
+                ))}
+            </ul>
+          }
+        </>
+      )
+    }
+  }
+
+
+  const EventTypes = () => {
+    if (checkedTypes && setCheckedTypes) {
+      return (
+        <>
+          <button
+            onClick={toggleTypes}
+            className="event-filter-title"
+          >
+            EVENT TYPE
+            <i className="fa fa-angle-down event-filter-expandable-icon" aria-hidden="true"></i>
+          </button>
+          { showTypes &&
+            <ul className="event-filter-checkbox-list">
+                { alphaOrder(EVENT_TYPES).map(item => (
+                  <li key={item.id}>
+                    <label key={item.id}>
+                      <Checkbox
+                        name={item.id}
+                        checked={checkedTypes[item.id]}
+                        onChange={handleChange}
+                      />
+                      {item.name}
+                    </label>
+                  </li>
+                )) }
+            </ul>
+          }
+        </>
+      )
+    }
+  }
+
+  return (
+    <div className="margin-bottom-10">
+      {WorkingGroups()}
+      {EventTypes()}
+    </div>
+  )
+}
+
+PastEventsFilters.propTypes = {
+  checkedTypes: PropTypes.object,
+  setCheckedTypes: PropTypes.func,
+  checkedWorkingGroups: PropTypes.object,
+  setCheckedWorkingGroups: PropTypes.func,
+}
+
+export default PastEventsFilters

--- a/js/components/pastEvents/PastEventsList.js
+++ b/js/components/pastEvents/PastEventsList.js
@@ -1,25 +1,27 @@
 import React from 'react';
 import EventCard from '../EventCard';
+import Loading from '../Loading';
 
-const PastEventsList = ({ events }) => {
-    return (
-        <div className="container">
-          <div className="row margin-bottom-20">
-            <div className="col-md-6">
-              {/* Filters will be here */}
-              Filters...
-            </div>
-    
-            <div className="col-md-18 event-list-wrapper">
-              {events.map((event) => (
-                <div className="col-md-12 max-min-width past-event-fade-in" key={event.id}>
-                  <EventCard event={event} />
-                </div>
-              ))}
-            </div>
+const PastEventsList = ({ events, isFetchingMore, fetchMore, paras }) => {
+
+  return (
+    <> 
+      <div className="col-md-18 event-list-wrapper">
+        {events.map((event) => (
+          <div className="col-md-12 max-min-width" key={event.id}>
+            <EventCard event={event} />
           </div>
+        ))}
+  
+        <div className="past-event-container">
+          { isFetchingMore && <Loading /> }
+          { !isFetchingMore && !paras && <button className="btn btn-primary" onClick={fetchMore}>Load More</button>}
+          { !isFetchingMore && paras && <button className="btn btn-primary" onClick={() => fetchMore(paras)}>Load More</button>}
         </div>
-      )
+      </div>
+
+    </>
+  )
 }
 
 export default PastEventsList

--- a/js/components/pastEvents/PastEventsList.js
+++ b/js/components/pastEvents/PastEventsList.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import EventCard from '../EventCard';
+
+const PastEventsList = ({ events }) => {
+    return (
+        <div className="container">
+          <div className="row margin-bottom-20">
+            <div className="col-md-6">
+              {/* Filters will be here */}
+              Filters...
+            </div>
+    
+            <div className="col-md-18 event-list-wrapper">
+              {events.map((event) => (
+                <div className="col-md-12 max-min-width past-event-fade-in" key={event.id}>
+                  <EventCard event={event} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )
+}
+
+export default PastEventsList

--- a/less/events.less
+++ b/less/events.less
@@ -233,6 +233,15 @@
 }
 /** CustomSearch Style ends **/
 
+/** past events style **/
+.past-event-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/** past events style end **/
+
 @media screen and (max-width: 991px) {
     .max-min-width {
         min-width: 100%;


### PR DESCRIPTION
Fix #6 

Have done:
Implemented checkbox filtering and without filtering loading with calling apis with pages and paras.

TODO:

- [x] Implement searchbar filtering with apis
- [x] Implement past events together with upcoming 

---------Update-2020-10-01-----------------------

- [ ] checkbox "Include past events"
By default, show upcoming events, if include past events, after upcoming events finished loading, show past events

- [ ] greyscale past events, and also include a header as a separation that says: Past Events before we list all the past events.

- [ ] remove the Unknown "Event type"


Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>